### PR TITLE
Fix missing C API error checks.

### DIFF
--- a/src/jsonyx/_speedups.c
+++ b/src/jsonyx/_speedups.c
@@ -1457,6 +1457,10 @@ encoder_listencode_obj(PyEncoderObject *s, PyObject *markers, _PyUnicodeWriter *
              && !PyByteArray_Check(obj) && !PyBytes_Check(obj)
              && !PyMemoryView_Check(obj) && !PyUnicode_Check(obj))
     {
+        // See https://github.com/python/cpython/issues/123593 
+        if (PyErr_Occurred())
+            return -1;
+
         if (_Py_EnterRecursiveCall(" while encoding a JSON object"))
             return -1;
         rv = encoder_listencode_sequence(s, markers, writer, obj, newline_indent);
@@ -1464,6 +1468,9 @@ encoder_listencode_obj(PyEncoderObject *s, PyObject *markers, _PyUnicodeWriter *
         return rv;
     }
     else if (PyObject_IsInstance(obj, (PyObject *)s->Mapping)) {
+        if (PyErr_Occurred())
+            return -1;
+
         if (_Py_EnterRecursiveCall(" while encoding a JSON object"))
             return -1;
         rv = encoder_listencode_mapping(s, markers, writer, obj, newline_indent);

--- a/src/jsonyx/_speedups.c
+++ b/src/jsonyx/_speedups.c
@@ -1453,7 +1453,7 @@ encoder_listencode_obj(PyEncoderObject *s, PyObject *markers, _PyUnicodeWriter *
             return -1;
         return _steal_accumulate(writer, encoded);
     }
-    else if (PyObject_IsInstance(obj, (PyTypeObject *)s->Sequence)
+    else if (PyObject_IsInstance(obj, (PyObject *)s->Sequence)
              && !PyByteArray_Check(obj) && !PyBytes_Check(obj)
              && !PyMemoryView_Check(obj) && !PyUnicode_Check(obj))
     {
@@ -1463,7 +1463,7 @@ encoder_listencode_obj(PyEncoderObject *s, PyObject *markers, _PyUnicodeWriter *
         _Py_LeaveRecursiveCall();
         return rv;
     }
-    else if (PyObject_IsInstance(obj, (PyTypeObject *)s->Mapping)) {
+    else if (PyObject_IsInstance(obj, (PyObject *)s->Mapping)) {
         if (_Py_EnterRecursiveCall(" while encoding a JSON object"))
             return -1;
         rv = encoder_listencode_mapping(s, markers, writer, obj, newline_indent);


### PR DESCRIPTION
See [my comment](https://github.com/python/cpython/issues/123593#issuecomment-2325030663).

Likewise, this fixes a memory leak that I spotted (double incref on the value returned from `PyObject_CallOneArg`), and fixes an incorrect cast to `PyTypeObject *`.

Note that this is not an exhaustive search, there could be ones that I missed.